### PR TITLE
Use relative path, instead of absolute path

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,7 +25,7 @@
     <div class="container">
       <!--[if lt IE 9]><p class=chromeframe>お使いのウェブヴラウザは古いため，当サイトのコンテンツを正常に表示できません．<br><a href="http://browsehappy.com/">最新のウェブブラウザ</a>で閲覧する事をお勧めします．</p><![endif]-->
       <div id="logo">
-        <a href="/">
+        <a href="./">
           <img src="img/logo.png" alt="{{ site.title }}">
           <div id="claim">
             あなたが横浜市に納めた税金がどこで使われているかをお示しします
@@ -34,14 +34,14 @@
       </div>
       <nav>
         <ul class="nav nav-tabs">
-          <li><a href="/contact.html">お問い合わせ</a></li>
-          <li><a href="/links.html">関連サイト</a></li>
-          <li><a href="/team.html">開発者</a></li>
-          <li><a href="/sources.html">データの出所</a></li>
-          <li><a href="/about.html">このサイトについて</a></li>
-          <li><a href="/bubbletree.html">使途別予算額</a></li>
+          <li><a href="./contact.html">お問い合わせ</a></li>
+          <li><a href="./links.html">関連サイト</a></li>
+          <li><a href="./team.html">開発者</a></li>
+          <li><a href="./sources.html">データの出所</a></li>
+          <li><a href="./about.html">このサイトについて</a></li>
+          <li><a href="./bubbletree.html">使途別予算額</a></li>
           <!--li><a href="bubbletree-map.html">Country &amp; Regional Analysis</a></li-->
-          <li><a href="/">使途一日あたり</a></li>
+          <li><a href="./">使途一日あたり</a></li>
         </ul>
       </nav>
       <script type="text/javascript">
@@ -102,11 +102,3 @@
   </script>
 </body>
 </html>
-
-
-
-
-
-
-
-


### PR DESCRIPTION
if you create orezeni website as a GitHub Project Page,
these links will be dead.

I fixed it.

<hr>

もしOrezeniのウェブサイトをGitHub Project Pageとして公開しようとすると、
これらのリンクが切れてしまいます。

なので、なおしました。
