### PR TITLE
Add iconv to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ gem 'redcarpet',  '=2.1.1'
 gem 'maruku',     '=0.6.0'
 gem 'rdiscount',  '=1.6.8'
 gem 'RedCloth',   '=4.2.9'
-gem "rake"
-
+gem 'rake'
+gem 'iconv'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ GEM
       fast-stemmer (>= 1.0.0)
     directory_watcher (1.4.1)
     fast-stemmer (1.0.2)
+    iconv (1.0.4)
     jekyll (0.12.0)
       classifier (~> 1.3)
       directory_watcher (~> 1.1)
@@ -32,6 +33,7 @@ PLATFORMS
 
 DEPENDENCIES
   RedCloth (= 4.2.9)
+  iconv
   jekyll (= 0.12.0)
   liquid (= 2.4.1)
   maruku (= 0.6.0)


### PR DESCRIPTION
Iconv was removed in Ruby 2.0.0.
https://www.ruby-lang.org/en/news/2013/02/24/ruby-2-0-0-p0-is-released/

Add iconv gem for compatibility
